### PR TITLE
Add types

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,1 @@
-;;; Directory Local Variables
-;;; For more information see (info "(emacs) Directory Variables")
-
-((haskell-mode
-  (haskell-stylish-on-save nil)
-  (intero-targets "hpython:lib" "hpython:test:hpython-tests")))
+((nil .  ((run-tng-format-on-save . nil))))

--- a/src/Language/Python/DSL.hs
+++ b/src/Language/Python/DSL.hs
@@ -1573,7 +1573,7 @@ chainEq t (a:as) =
   SmallStatement
     (Indents [] (Ann ()))
     (MkSmallStatement
-       (Assign (Ann ()) t $ (,) (MkEquals [Space]) <$> (a :| as))
+       (Assign (Ann ()) t ((,) (MkEquals [Space]) <$> (a :| as)) Nothing)
        []
        Nothing
        Nothing
@@ -1585,7 +1585,7 @@ chainEq t (a:as) =
   SmallStatement
     (Indents [] (Ann ()))
     (MkSmallStatement
-       (Assign (Ann ()) (a & trailingWhitespace .~ [Space]) $ pure (MkEquals [Space], b))
+       (Assign (Ann ()) (a & trailingWhitespace .~ [Space]) (pure (MkEquals [Space], b)) Nothing)
        []
        Nothing
        Nothing

--- a/src/Language/Python/Internal/Parse.hs
+++ b/src/Language/Python/Internal/Parse.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses  #-}
 {-# LANGUAGE RankNTypes             #-}
 {-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TupleSections          #-}
 
 {-|
 Module      : Language.Python.Internal.Parse
@@ -381,13 +382,27 @@ exprList ws =
      optional (commaSep1' ws $ expr ws))
 
 exprOrStarList :: MonadParsec e PyTokens m => m Whitespace -> m (Expr SrcInfo)
-exprOrStarList ws =
+exprOrStarList ws = do
   (\e -> maybe e (uncurry $ Tuple (e ^. exprAnn) e)) <$>
-  (expr ws <|> starExpr ws) <*>
-  optional
-    ((,) <$>
-     (snd <$> comma ws) <*>
-     optional (commaSep1' ws $ expr ws <|> starExpr ws))
+    (expr ws <|> starExpr ws) <*>
+    optional
+      ((,) <$>
+        (snd <$> comma ws) <*>
+        optional (commaSep1' ws $ expr ws <|> starExpr ws))
+  
+
+exprWithType :: MonadParsec e PyTokens m => m Whitespace -> m (Expr SrcInfo, Maybe ([Whitespace], Expr SrcInfo))
+exprWithType ws = do
+  e <- ((\e -> maybe e (uncurry $ Tuple (e ^. exprAnn) e)) <$>
+         (expr ws <|> starExpr ws) <*>
+         optional
+           ((,) <$>
+            (snd <$> comma ws) <*>
+            optional (commaSep1' ws $ expr ws <|> starExpr ws)))
+  mte <- optional ((\(_, ws) -> (ws,)) <$> token anySpace (\case; TkColon{} -> True; _ -> False) ":" <*> expr ws)
+  pure (e, mte)
+
+  
 
 compIf :: MonadParsec e PyTokens m => m (CompIf SrcInfo)
 compIf =
@@ -761,7 +776,7 @@ orExpr ws =
            (snd <$> comma anySpace) <*>
            optional (commaSep1' anySpace (expr anySpace <|> starExpr anySpace))))) <*>
       (snd <$> token ws (\case; TkRightBracket{} -> True; _ -> False) "]")
-
+      
     doubleStarExpr ws =
       (\(tk, sp) -> DictUnpack (pyTokenAnn tk) sp) <$>
       doubleStar ws <*>
@@ -941,13 +956,13 @@ simpleStatement =
       mkAugAssign DoubleSlashEq (\case; TkDoubleSlashEq{} -> True; _ -> False) "//="
 
     exprOrAssignSt =
-      (\a ->
+      (\(a, mt) ->
          maybe
            (Expr (a ^. exprAnn) a)
            (either
-              (Assign (a ^. exprAnn) a)
+              (\e -> Assign (a ^. exprAnn) a e mt)
               (uncurry $ AugAssign (a ^. exprAnn) a))) <$>
-      exprOrStarList space <*>
+      exprWithType space <*>
       optional
         (Left <$>
          some1

--- a/src/Language/Python/Internal/Render.hs
+++ b/src/Language/Python/Internal/Render.hs
@@ -1149,13 +1149,20 @@ renderSimpleStatement (Return _ ws expr) = do
   traverse_ renderWhitespace ws
   traverse_ parensGenerator expr
 renderSimpleStatement (Expr _ expr) = renderYield parensGenerator expr
-renderSimpleStatement (Assign _ lvalue rvalues) = do
+renderSimpleStatement (Assign _ lvalue rvalues mte) = do
   renderExpr lvalue
+  case mte of
+    Nothing -> pure ()
+    Just (d, te) -> do
+      singleton $ TkColon ()
+      traverse_ renderWhitespace d
+      renderExpr te
   traverse_
     (\(ws2, rvalue) -> do
        renderEquals ws2
        renderYield parensGenerator rvalue)
     rvalues
+
 renderSimpleStatement (AugAssign _ lvalue as rvalue) = do
   renderExpr lvalue
   renderAugAssign as

--- a/src/Language/Python/Internal/Syntax/IR.hs
+++ b/src/Language/Python/Internal/Syntax/IR.hs
@@ -162,7 +162,7 @@ data CompoundStatement a
 data SimpleStatement a
   = Return a [Whitespace] (Maybe (Expr a))
   | Expr a (Expr a)
-  | Assign a (Expr a) (NonEmpty (Equals, Expr a))
+  | Assign a (Expr a) (NonEmpty (Equals, Expr a)) (Maybe ([Whitespace], Expr a))
   | AugAssign a (Expr a) (AugAssign a) (Expr a)
   | Pass a [Whitespace]
   | Break a [Whitespace]
@@ -877,10 +877,11 @@ fromIR_SimpleStatement
   -> Validation (NonEmpty e) (Syntax.SimpleStatement '[] a)
 fromIR_SimpleStatement ex =
   case ex of
-    Assign a b c ->
+    Assign a b c d->
       Syntax.Assign (Ann a) <$>
       fromIR_expr b <*>
-      traverseOf (traverse._2) fromIR_expr c
+      traverseOf (traverse._2) fromIR_expr c <*>
+      traverseOf (traverse._2) fromIR_expr d
     Return a b c -> Syntax.Return (Ann a) b <$> traverse fromIR_expr c
     Expr a b -> Syntax.Expr (Ann a) <$> fromIR_expr b
     AugAssign a b c d ->

--- a/src/Language/Python/Optics/Newlines.hs
+++ b/src/Language/Python/Optics/Newlines.hs
@@ -516,7 +516,7 @@ instance HasNewlines (SimpleStatement v a) where
     case s of
       Return a b c -> Return a <$> _Newlines fun b <*> _Newlines fun c
       Expr a b -> Expr a <$> _Newlines fun b
-      Assign a b c -> Assign a <$> _Newlines fun b <*> _Newlines fun c
+      Assign a b c d -> Assign a <$> _Newlines fun b <*> _Newlines fun c <*> _Newlines fun d
       AugAssign a b c d ->
         AugAssign a <$>
         _Newlines fun b <*>

--- a/src/Language/Python/Syntax/Statement.hs
+++ b/src/Language/Python/Syntax/Statement.hs
@@ -304,7 +304,7 @@ data SimpleStatement (v :: [*]) a
   -- | @\<expr\> (\'=\' \<spaces\> \<expr\>)+@
   --
   -- https://docs.python.org/3.5/reference/simple_stmts.html#assignment-statements
-  | Assign (Ann a) (Expr v a) (NonEmpty (Equals, Expr v a))
+  | Assign (Ann a) (Expr v a) (NonEmpty (Equals, Expr v a)) (Maybe ([Whitespace], Expr v a))
   -- | @\<expr\> \<augassign\> \<expr\>@
   --
   -- https://docs.python.org/3.5/reference/simple_stmts.html#augmented-assignment-statements
@@ -379,7 +379,7 @@ instance HasExprs SimpleStatement where
       x
   _Exprs f (Return a ws e) = Return a ws <$> traverse f e
   _Exprs f (Expr a e) = Expr a <$> f e
-  _Exprs f (Assign a e1 es) = Assign a <$> f e1 <*> traverseOf (traverse._2) f es
+  _Exprs f (Assign a e1 es mte) = Assign a <$> f e1 <*> (traverseOf (traverse._2) f es) <*> (traverseOf (traverse._2) f mte)
   _Exprs f (AugAssign a e1 as e2) = AugAssign a <$> f e1 <*> pure as <*> f e2
   _Exprs _ p@Pass{} = pure $ p ^. unvalidated
   _Exprs _ p@Break{} = pure $ p ^. unvalidated

--- a/src/Language/Python/Validate/Scope.hs
+++ b/src/Language/Python/Validate/Scope.hs
@@ -343,12 +343,12 @@ validateSimpleStatementScope (Raise a ws f) =
     f
 validateSimpleStatementScope (Return a ws e) = Return a ws <$> traverse validateExprScope e
 validateSimpleStatementScope (Expr a e) = Expr a <$> validateExprScope e
-validateSimpleStatementScope (Assign a l rs) =
+validateSimpleStatementScope (Assign a l rs _) =
   Assign a <$>
   validateAssignExprScope l <*>
   ((\a b -> case a of; [] -> b :| []; a : as -> a :| snoc as b) <$>
    traverseOf (traverse._2) validateAssignExprScope (NonEmpty.init rs) <*>
-   (\(ws, b) -> (,) ws <$> validateExprScope b) (NonEmpty.last rs))
+   (\(ws, b) -> (,) ws <$> validateExprScope b) (NonEmpty.last rs)) <*> pure Nothing
 validateSimpleStatementScope (AugAssign a l aa r) =
   (\l' -> AugAssign a l' aa) <$>
   validateExprScope l <*>

--- a/src/Language/Python/Validate/Syntax.hs
+++ b/src/Language/Python/Validate/Syntax.hs
@@ -954,7 +954,7 @@ validateSimpleStatementSyntax (Return a ws expr) =
 validateSimpleStatementSyntax (Expr a expr) =
   Expr a <$>
   validateExprSyntax expr
-validateSimpleStatementSyntax (Assign a lvalue rs) =
+validateSimpleStatementSyntax (Assign a lvalue rs _) =
   liftVM0 ask `bindVM` \sctxt ->
     let
       assigns =
@@ -974,7 +974,7 @@ validateSimpleStatementSyntax (Assign a lvalue rs) =
             validateAssignmentSyntax (getAnn a) b)
          (NonEmpty.init rs) <*>
        (\(ws, b) -> (,) <$> validateEquals (getAnn a) ws <*> validateExprSyntax b)
-         (NonEmpty.last rs)) <*
+         (NonEmpty.last rs)) <*> pure Nothing <*
       liftVM0 (modify (assigns ++))
 validateSimpleStatementSyntax (AugAssign a lvalue aa rvalue) =
   AugAssign a <$>

--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -2,11 +2,11 @@
 module Parser (parserTests) where
 
 import Hedgehog
-
 import Language.Python.Internal.Token (PyToken(..))
 import Language.Python.Parse (parseStatement)
+import Language.Python.Render (showStatement)
 
-import Helpers (shouldBeParseError)
+import Helpers (shouldBeParseError, shouldBeParseSuccess)
 
 parserTests :: Group
 parserTests = $$discover
@@ -19,3 +19,11 @@ prop_parser_1 =
       res = parseStatement "test" e
 
     shouldBeParseError 1 13 (TkStar ()) res
+
+prop_parser_3 :: Property
+prop_parser_3 =
+  withTests 1 . property $ do
+    let
+      e = "a : List[int] = []"
+    tree <- shouldBeParseSuccess parseStatement e
+    showStatement tree === e


### PR DESCRIPTION
We can now parse stuff like `a : List[int] = []`